### PR TITLE
after first browser render, check sizes again (fixes #8)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -172,6 +172,7 @@
         "afterColon": true
       }
     ],
+    "keyword-spacing": 2,
     "max-nested-callbacks": [
       2,
       3
@@ -221,10 +222,6 @@
       "never"
     ],
     "sort-vars": 0,
-    "space-after-keywords": [
-      1,
-      "always"
-    ],
     "space-before-blocks": 0,
     "space-before-function-paren": [
       1,
@@ -243,7 +240,6 @@
       "never"
     ],
     "space-infix-ops": 2,
-    "space-return-throw-case": 2,
     "space-unary-ops": [
       1,
       {

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "5"
+  - "stable"
 
 script:
   - "npm run nsp && npm run lint && npm test"
@@ -13,3 +14,9 @@ sudo: false
 
 before_install:
  - "npm install -g npm@latest"
+
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start

--- a/index.jsx
+++ b/index.jsx
@@ -25,6 +25,7 @@ export default class ElementQuery extends Component {
           if (size === 0) {
             return new Error(`${componentName} received a width of \`${size}\` for \`${props.name}\`. Widths are min-widths, and should be treated as "mobile-first". The default state can be set with the \`default\` prop, or even better with the "default" styles in CSS.`)
           }
+          return null
         }
     })).isRequired
     , makeClassName: PropTypes.func
@@ -60,9 +61,9 @@ export default class ElementQuery extends Component {
     ElementQuery.unregister(this)
   }
 
-static _isListening = false
+  static _isListening = false
 
-static _componentMap = new Map()
+  static _componentMap = new Map()
 
   // use only one global listener … for perf!
   static listen () {
@@ -110,6 +111,7 @@ static _componentMap = new Map()
     let matchedSize = ''
     let matchedWidth = smallestSize.width
 
+    // use Array#some() here because #forEach() has no early exit
     sizes.some((test) => {
       // check for:
       // 1. the el width is greater or equal to the test width
@@ -117,11 +119,10 @@ static _componentMap = new Map()
       if (width >= test.width && width >= matchedWidth) {
         matchedSize = test.name
         matchedWidth = test.width
+        return false
       }
       // once that condition isn't true, we've found the correct match; bail
-      else {
-        return true
-      }
+      return true
     })
     component.setSize(matchedSize)
   }

--- a/index.jsx
+++ b/index.jsx
@@ -51,6 +51,10 @@ export default class ElementQuery extends Component {
 
   componentDidMount () {
     ElementQuery.sizeComponent(this, this.state.sizes)
+    // wait a few frames then check sizes again
+    raf(() => raf(() => {
+      ElementQuery.sizeComponent(this, this.state.sizes)
+    }))
   }
 
   componentWillReceiveProps (newProps) {

--- a/index.jsx
+++ b/index.jsx
@@ -1,9 +1,9 @@
 import React, {PropTypes, Component, Children, cloneElement} from 'react'
 import {findDOMNode} from 'react-dom'
-import identity from 'lodash/utility/identity'
-import sortBy from 'lodash/collection/sortBy'
-import first from 'lodash/array/first'
-import isNumber from 'lodash/lang/isNumber'
+import identity from 'lodash.identity'
+import sortBy from 'lodash.sortby'
+import first from 'lodash.first'
+import isNumber from 'lodash.isnumber'
 import raf from 'raf'
 import pureRender from 'pure-render-decorator'
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   "browser": "index.es5",
   "devDependencies": {
     "babel": "^5.6.14",
-    "babel-eslint": "^4.1.3",
+    "babel-eslint": "^6.0.4",
     "babel-plugin-closure-elimination": "^0.0.2",
     "babel-plugin-undefined-to-void": "^1.1.6",
     "babel-runtime": "^5.6.15",
@@ -63,8 +63,8 @@
     "browserify": "^12.0.1",
     "dmn": "^1.0.5",
     "doctoc": "^0.15.0",
-    "eslint": "^1.7.3",
-    "eslint-plugin-react": "^3.6.3",
+    "eslint": "^2.8.0",
+    "eslint-plugin-react": "^5.0.1",
     "ghooks": "^0.3.2",
     "hihat": "^2.5.0",
     "in-publish": "^2.0.0",
@@ -88,7 +88,7 @@
   },
   "dependencies": {
     "lodash": "^3.10.1",
-    "pure-render-decorator": "^0.2.0",
+    "pure-render-decorator": "^1.1.0",
     "raf": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,10 @@
     "react-dom": ">=0.14.1"
   },
   "dependencies": {
-    "lodash": "^3.10.1",
+    "lodash.first": "^3.0.0",
+    "lodash.identity": "^3.0.0",
+    "lodash.isnumber": "^3.0.3",
+    "lodash.sortby": "^4.4.2",
     "pure-render-decorator": "^1.1.0",
     "raf": "^3.0.0"
   }

--- a/scripts.sh
+++ b/scripts.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 function lint(){
-  eslint --no-eslintrc --config .eslintrc "${@-.}" --ext .jsx --ext .js --ext .es6
+  eslint --no-eslintrc --config .eslintrc.json "${@-.}" --ext .jsx --ext .js --ext .es6
 }
 
 function git_require_clean_work_tree(){


### PR DESCRIPTION
I've added a second call to `sizeComponent()` a few frames after `componentDidMount()`.

I tried `setTimeout(fn, 0)` and that was too early, and I also tried `setTimeout(fn, 1e3)` and it worked but the delay was far too visibly obvious.

Let me know if you'd like a squash, or if you'd like me to undo some of the other changes I snuck in (as separate commits), or if you have other comments.

Fixes #8 