### PR TITLE
Prevent sizeComponent on unmounted components

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -45,6 +45,8 @@ export default class ElementQuery extends PureComponent {
   }
 
   componentDidMount () {
+    this._isMounted = true
+
     ElementQuery.register({
       component: this
       , sizes: this.state.sizes
@@ -59,11 +61,13 @@ export default class ElementQuery extends PureComponent {
 
     // wait a few frames then check sizes again
     raf(() => raf(() => {
-      ElementQuery.sizeComponent({
-        component: this
-        , sizes: this.state.sizes
-        , node: this.node
-      })
+      if (this._isMounted) {
+        ElementQuery.sizeComponent({
+          component: this
+          , sizes: this.state.sizes
+          , node: this.node
+        })
+      }
     }))
   }
 
@@ -72,6 +76,7 @@ export default class ElementQuery extends PureComponent {
   }
 
   componentWillUnmount () {
+    this._isMounted = false
     ElementQuery.unregister(this)
   }
 


### PR DESCRIPTION
Occasionally it fires warnings trying to size components that are already unmounted, I guess because of the raf delay. This fix prevents the sizing of components that are unmounted (or about to be unmounted).